### PR TITLE
Specify “task” bug type when filing a new bug

### DIFF
--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -440,6 +440,7 @@ struct FileBug<'a> {
     version: &'a str,
     summary: String,
     description: String,
+    type: String,
     priority: &'a str,
     see_also: Vec<String>,
 }
@@ -464,6 +465,7 @@ pub fn file_bug(
         version: "unspecified",
         summary,
         description,
+        type: "task",
         priority: "P3",
         see_also: urls,
     };


### PR DESCRIPTION
Hi there! I have realized that your [Mozilla Apprentice bot](https://bugzilla.mozilla.org/user_profile?user_id=637493) is filing bugs on Bugzilla without a bug type specified. The `type` field is currently optional, but we’ll soon [make it required](https://bugzilla.mozilla.org/show_bug.cgi?id=1562364). Let’s use the “task” type for all new bugs. Sometimes changes could be “enhancement” but engineers can change the type anytime if needed.